### PR TITLE
Fix webpack build error "SyntaxError: Unexpected token )"

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -16,7 +16,7 @@ module.exports = {
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
       /debug/,
-      process.cwd() + '/support/debug.js',
+      process.cwd() + '/support/debug.js'
     ),
   ],
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
       /debug/,
-      process.cwd() + '/support/noop.js',
+      process.cwd() + '/support/noop.js'
     ),
   ],
   module: {


### PR DESCRIPTION
Webpack@1.6.0 gives build error as below, remove extra `,` to fix the build and dev build
```
D:\github\weapp.socket.io-master\webpack.config.dev.js:20
    ),
    ^

SyntaxError: Unexpected token )
```